### PR TITLE
Added full bet tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# vim temporary files
+*.swp

--- a/server.py
+++ b/server.py
@@ -154,10 +154,11 @@ def page_action():
 			game_data['kitty'] = []
 		# Clear the table
 		if action == 'clear':
-			game_data['floor'] = game_data['table']
-			game_data['floor'].reverse();
-			game_data['table'] = []
-			# game_data['table'] = [-1] * len(game_data['table'])
+			if (game_data['table']):
+				game_data['floor'] = game_data['table']
+				game_data['floor'].reverse();
+				game_data['table'] = []
+				# game_data['table'] = [-1] * len(game_data['table'])
 		if action == 'pickup':
 			# Remove the thing from the table and the floor.
 			for i in game_data['table']:

--- a/server.py
+++ b/server.py
@@ -150,6 +150,7 @@ def page_action():
 		# Clear the table
 		if action == 'clear':
 			game_data['floor'] = game_data['table']
+			game_data['floor'].reverse();
 			game_data['table'] = []
 			# game_data['table'] = [-1] * len(game_data['table'])
 		if action == 'pickup':

--- a/server.py
+++ b/server.py
@@ -59,7 +59,6 @@ def sort_hands():
 
 def set_trump(suit):
 	global card_val
-	game_data['trump'] = suit
 	card_val = copy.copy(card_val_init)
 	for i in card_val:
 		if suit in i:

--- a/server.py
+++ b/server.py
@@ -57,6 +57,14 @@ def sort_hands():
 	for i in game_data['hands']:
 		i.sort(key = lambda x: card_val.get(x, -1), reverse = True)
 
+
+def isMisere(string):
+	return string == 'Misere' or string == 'Open Misere'
+
+def getTrump(betSuit):
+	if isMisere(betSuit) or betSuit == '': return 'No Trump'
+	else: return betSuit
+
 def set_trump(suit):
 	global card_val
 	card_val = copy.copy(card_val_init)
@@ -93,9 +101,6 @@ def actionDeal():
 	# game_data['betSuit'] also can take on 'Misere' and 'Open Misere' values
 	game_data['betAmount'] = -1
 	game_data['betSuit'] = ''
-
-def isMisere(string):
-	return string == 'Misere' or string == 'Open Misere'
 
 @bottle.route('/')
 def page_index():
@@ -181,10 +186,7 @@ def page_action():
 				game_data['betAmount'] = -1
 			game_data['betSuit'] = betSuit
 			# Set the trump suit
-			if isMisere(betSuit):
-				set_trump('No Trump')
-			else:
-				set_trump(betSuit);
+			set_trump(getTrump(betSuit))
 		# Increment version counter
 		game_data['version_id'] += 1
 		# Save it to disk

--- a/server.py
+++ b/server.py
@@ -90,6 +90,7 @@ def actionDeal():
 			game_data['hands'][player-1].append(deck_init[c])
 	for c in range(40, 43):
 		game_data['kitty'].append(deck_init[c])
+	set_trump('No Trump')
 	# game_data['betSuit'] also can take on 'Misere' and 'Open Misere' values
 	game_data['betAmount'] = -1
 	game_data['betSuit'] = ''
@@ -179,6 +180,11 @@ def page_action():
 			if isMisere(game_data['betSuit']) or isMisere(betSuit):
 				game_data['betAmount'] = -1
 			game_data['betSuit'] = betSuit
+			# Set the trump suit
+			if isMisere(betSuit):
+				set_trump('No Trump')
+			else:
+				set_trump(betSuit);
 		# Increment version counter
 		game_data['version_id'] += 1
 		# Save it to disk

--- a/static/game.html
+++ b/static/game.html
@@ -18,7 +18,7 @@
 
 						<td class="layout">
 							<p id="yourName">You are nobody.</p>
-							<p id="trumpSuit">There is no trump suit.</p>
+							<p id="betInfo">There is no bet.</p>
 
 							<h2>Controls</h2>
 							<h3>Actions</h3>
@@ -30,12 +30,21 @@
 							<button onclick="changePlayer(1);">Be player 2</button>
 							<button onclick="changePlayer(2);">Be player 3</button>
 							<button onclick="changePlayer(3);">Be player 4</button>
-							<h3>Set Trump Suit</h3>
-							<button onclick="setTrump('No Trump');">No Trump</button>
-							<button onclick="setTrump('Spades');">Spades</button>
-							<button onclick="setTrump('Clubs');">Clubs</button>
-							<button onclick="setTrump('Hearts');">Hearts</button>
-							<button onclick="setTrump('Diamonds');">Diamonds</button>
+							<h3>Set Bet</h3>
+							<button onclick="setBetAmount(6);">6</button>
+							<button onclick="setBetAmount(7);">7</button>
+							<button onclick="setBetAmount(8);">8</button>
+							<button onclick="setBetAmount(9);">9</button>
+							<button onclick="setBetAmount(10);">10</button>
+							<br>
+							<button onclick="setBetSuit('Spades');">&spades;</button>
+							<button onclick="setBetSuit('Clubs');">&clubs;</button>
+							<button onclick="setBetSuit('Diamonds');">&diams;</button>
+							<button onclick="setBetSuit('Hearts');">&hearts;</button>
+							<button onclick="setBetSuit('No Trump');">No Trump</button>
+							<br>
+							<button onclick="setBetSuit('Misere');">Misere</button>
+							<button onclick="setBetSuit('Open Misere');">Open Misere</button>
 						
 							<h2>Kitty</h2>
 							<p id="kittyCards">Nothing here...</p>

--- a/static/game.js
+++ b/static/game.js
@@ -55,7 +55,36 @@ function updateGameView(data, status) {
 		$("#myCards").html(hand_html);
 		$("#playedCards").html(makeTableTable(data.table));
 		$("#floorCards").html(makeTableTable(data.floor));
-		$("#trumpSuit").text("The trump suit is " + data['trump']);
+		var betInfo = 'There is no bet';
+		if (data.betAmount != -1 || data.betSuit != '') {
+			var betValue = 0;
+			betInfo = 'The bet is';
+			if (data.betSuit == 'Misere') {
+				betInfo += ' Misere';
+				betValue = 250;
+			} else if (data.betSuit == 'Open Misere') {
+				betInfo += ' Open Misere';
+				betValue = 500;
+			} else {
+				if (data.betAmount != -1) {
+					betInfo += ' ' + data.betAmount;
+					betValue += 100 * (data.betAmount - 6);
+				}
+				if (data.betSuit != '') {
+					betInfo += ' ' + data.betSuit;
+					if (data.betSuit == 'Spades') betValue += 40;
+					if (data.betSuit == 'Clubs') betValue += 60;
+					if (data.betSuit == 'Diamonds') betValue += 80;
+					if (data.betSuit == 'Hearts') betValue += 100;
+					if (data.betSuit == 'No Trump') betValue += 120;
+				}
+				// only display bet value if both the bet suit and amount have been chosen
+				if (data.betAmount == -1 || data.betSuit == '') betValue = 0;
+			}
+			// betValue == 0 means to not display it
+			if (betValue) betInfo += ' (' + betValue + ' points)';
+		}
+		$("#betInfo").text(betInfo);
 		last_gamedata_version = data.version_id
 	}
 }
@@ -117,12 +146,23 @@ function uniAction(action_name) {
 	);
 }
 
-function setTrump(suit) {
+function setBetAmount(betAmount) {
 	$.post('/action',
 		{
-			'action': 'setTrump',
+			'action': 'setBetAmount',
 			'player': player_id,
-			'suit': suit
+			'betAmount': betAmount
+		},
+		updateGameView
+	);
+}
+
+function setBetSuit(betSuit) {
+	$.post('/action',
+		{
+			'action': 'setBetSuit',
+			'player': player_id,
+			'betSuit': betSuit
 		},
 		updateGameView
 	);

--- a/static/game.js
+++ b/static/game.js
@@ -71,27 +71,19 @@ function updateGameView(data, status) {
 		if (data.betAmount != -1 || data.betSuit != '') {
 			var betValue = 0;
 			betInfo = 'The bet is';
-			if (data.betSuit == 'Misere') {
-				betInfo += ' Misere';
-				betValue = 250;
-			} else if (data.betSuit == 'Open Misere') {
-				betInfo += ' Open Misere';
-				betValue = 500;
-			} else {
-				if (data.betAmount != -1) {
-					betInfo += ' ' + data.betAmount;
-					betValue += 100 * (data.betAmount - 6);
-				}
-				if (data.betSuit != '') {
-					betInfo += ' ' + data.betSuit;
-					if (data.betSuit == 'Spades') betValue += 40;
-					if (data.betSuit == 'Clubs') betValue += 60;
-					if (data.betSuit == 'Diamonds') betValue += 80;
-					if (data.betSuit == 'Hearts') betValue += 100;
-					if (data.betSuit == 'No Trump') betValue += 120;
-				}
-				// only display bet value if both the bet suit and amount have been chosen
-				if (data.betAmount == -1 || data.betSuit == '') betValue = 0;
+			// calculate bet name
+			if (data.betAmount != -1) betInfo += ' ' + data.betAmount;
+			if (data.betSuit != '') betInfo += ' ' + data.betSuit;
+			// calculate bet value
+			if (data.betSuit == 'Misere') betValue = 250;
+			else if (data.betSuit == 'Open Misere') betValue = 500;
+			else if (data.betAmount != -1 && data.betSuit != '') {
+				betValue = 100 * (data.betAmount - 6);
+				if (data.betSuit == 'Spades') betValue += 40;
+				if (data.betSuit == 'Clubs') betValue += 60;
+				if (data.betSuit == 'Diamonds') betValue += 80;
+				if (data.betSuit == 'Hearts') betValue += 100;
+				if (data.betSuit == 'No Trump') betValue += 120;
 			}
 			// betValue == 0 means to not display it
 			if (betValue) betInfo += ' (' + betValue + ' points)';

--- a/static/game.js
+++ b/static/game.js
@@ -180,6 +180,8 @@ function setBetAmount(betAmount) {
 }
 
 function setBetSuit(betSuit) {
+	if (betSuit == 'Misere' || betSuit == 'Open Misere') trump_suit = 'No Trump';
+	else trump_suit = betSuit;
 	$.post('/action',
 		{
 			'action': 'setBetSuit',

--- a/static/game.js
+++ b/static/game.js
@@ -2,6 +2,14 @@ var last_gamedata_version = -1;
 var player_id = -1;
 var trump_suit;
 
+function isMisere(betSuit) {
+	return betSuit == 'Misere' || betSuit == 'Open Misere';
+}
+function getTrump(betSuit) {
+	if (isMisere(betSuit) || betSuit == '') return 'No Trump';
+	else return betSuit;
+}
+
 function makeCardText(cardname) {
 	var result = cardname;
 	var is_trump = false;
@@ -44,7 +52,7 @@ function makeTableTable(cards) {
 // Update the game view with the given data.
 function updateGameView(data, status) {
 	if (player_id != -1 && data.version_id != last_gamedata_version) {
-		trump_suit = data.trump;
+		trump_suit = getTrump(data.betSuit);
 		var myhand = data.hands[player_id];
 		var table = data.table;
 		table.reverse();
@@ -148,9 +156,6 @@ function actionRedeal() {
 }
 
 function uniAction(action_name) {
-	if (action_name == 'redeal') {
-		trump_suit = 'No trump';
-	}
 	$.post('/action',
 		{
 			'action': action_name,
@@ -172,8 +177,6 @@ function setBetAmount(betAmount) {
 }
 
 function setBetSuit(betSuit) {
-	if (betSuit == 'Misere' || betSuit == 'Open Misere') trump_suit = 'No Trump';
-	else trump_suit = betSuit;
 	$.post('/action',
 		{
 			'action': 'setBetSuit',


### PR DESCRIPTION
EDIT: Also added keeping cards in the same order when they get cleared from the table... I'm not sure if the reversing was intentional?... but reversing the cards just seemed confusing and there was nothing in the code that suggested it was intentional...

Deprecated game_data['trump'] and (hopefully) fixed things that relied on it.
Instead there is now game_data['betSuit'] and game_data['betAmount'].
game_data['betSuit'] can take on either a suit, or 'No Trump', 'Misere' or 'Open Misere' (or default value of empty string). So where game_data['trump'] was used, instead there is a check for any misere-type bet and they are replaced by 'No Trump', for example in calls to set_trump(). In future it might be more concise to write a getTrump(suit) function to convert misere-type bets, instead of having if statements everywhere...
game_data['betAmount'] can take on any value from 6 to 10, or default value of -1.
